### PR TITLE
[hotfix] Resolved pattern recognition when parsing taskgraphs only for PTX

### DIFF
--- a/tornado-visualizer-fixed.py
+++ b/tornado-visualizer-fixed.py
@@ -66,35 +66,37 @@ class TornadoVisualizer:
         self.memory_objects = {}
         self.dependency_graph = nx.DiGraph()
         self.bytecode_details = []  # For detailed bytecode visualization
-        
+    
     def parse_log(self, log_content: str) -> None:
         """Parse the TornadoVM bytecode log and extract task graphs"""
         # Split the log into sections for each task graph
         pattern = r"Interpreter instance running bytecodes for:(.*?)bc:\s+END"
         graph_sections = re.findall(pattern, log_content, re.DOTALL)
-        
+
         for i, section in enumerate(graph_sections):
             graph_name = f"TaskGraph_{i}"
             # Try to extract graph name from task names if possible
             task_match = re.search(r"task ([\w\.]+)\.", section)
             if task_match:
                 graph_name = task_match.group(1)
-                
+
             self._parse_task_graph(section, graph_name)
-            
+
         # Build dependencies after all graphs are parsed
         self._build_dependencies()
-        
+ 
     def _parse_task_graph(self, section: str, graph_id: str) -> None:
         """Parse a single task graph section"""
         # Extract device and thread info
-        device_match = re.search(r"PTX -- (.*?) Running in thread:\s+(.*?)$", section, re.MULTILINE)
+        device_match = re.search(r"^\s*(.+?)\s+Running in thread:\s*(.*?)\s*$", section, re.MULTILINE)
         if not device_match:
-            return
-            
-        device = device_match.group(1)
-        thread = device_match.group(2).strip()
-        
+            # If we somehow miss the device line, don't bail; keep parsing ops anyway.
+            device = "Unknown device"
+            thread = "unknown"
+        else:
+            device = device_match.group(1).strip()
+            thread = device_match.group(2).strip()
+
         task_graph = TaskGraph(graph_id=graph_id, device=device, thread=thread)
         
         # Parse bytecode operations

--- a/tornado-visualizer-fixed.py
+++ b/tornado-visualizer-fixed.py
@@ -72,19 +72,19 @@ class TornadoVisualizer:
         # Split the log into sections for each task graph
         pattern = r"Interpreter instance running bytecodes for:(.*?)bc:\s+END"
         graph_sections = re.findall(pattern, log_content, re.DOTALL)
-
+        
         for i, section in enumerate(graph_sections):
             graph_name = f"TaskGraph_{i}"
             # Try to extract graph name from task names if possible
             task_match = re.search(r"task ([\w\.]+)\.", section)
             if task_match:
                 graph_name = task_match.group(1)
-
+                
             self._parse_task_graph(section, graph_name)
-
+            
         # Build dependencies after all graphs are parsed
         self._build_dependencies()
- 
+        
     def _parse_task_graph(self, section: str, graph_id: str) -> None:
         """Parse a single task graph section"""
         # Extract device and thread info

--- a/tornado-visualizer-fixed.py
+++ b/tornado-visualizer-fixed.py
@@ -91,8 +91,8 @@ class TornadoVisualizer:
         device_match = re.search(r"^\s*(.+?)\s+Running in thread:\s*(.*?)\s*$", section, re.MULTILINE)
         if not device_match:
             # If we somehow miss the device line, don't bail; keep parsing ops anyway.
-            device = "Unknown device"
-            thread = "unknown"
+            device = "Unknown Device"
+            thread = "Unknown Thread"
         else:
             device = device_match.group(1).strip()
             thread = device_match.group(2).strip()


### PR DESCRIPTION
This PR provides an update in the regex pattern match for TaskGraph device names. The current pattern match looks for PTX, while it should be orthogonal to the backend selection.