### PR TITLE
[fix] Sample image lookup by resolving parent path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ matplotlib>=3.8.2
 plotly>=5.18.0
 
 # Web application framework
-streamlit>=1.31.0
+streamlit>=1.40.0
 
 # Utility libraries
 pydantic==2.6.4

--- a/tornado-visualizer-fixed.py
+++ b/tornado-visualizer-fixed.py
@@ -1365,22 +1365,23 @@ class TornadoVisualizer:
         
         return fig
 
-def find_in_parents(relative_path: str) -> Optional[Path]:
-    """
-    Walk up from this script's directory and return the first path that exists.
-    Example: find_in_parents("docs/images/basic_view.png")
-    """
-    try:
-        start = Path(__file__).resolve().parent
-    except NameError:
-        # Fallback when __file__ is not available (rare in Streamlit)
-        start = Path.cwd().resolve()
-
-    for folder in [start, *start.parents]:
-        candidate = folder / relative_path
-        if candidate.exists():
-            return candidate
-    return None
+    @staticmethod
+    def find_in_parents(relative_path: str) -> Optional[Path]:
+        """
+        Walk up from this script's directory and return the first path that exists.
+        Example: find_in_parents("docs/images/basic_view.png")
+        """
+        try:
+            start = Path(__file__).resolve().parent
+        except NameError:
+            # Fallback when __file__ is not available (rare in Streamlit)
+            start = Path.cwd().resolve()
+        
+        for folder in [start, *start.parents]:
+            candidate = folder / relative_path
+            if candidate.exists():
+                return candidate
+        return None
 
 # Main Streamlit application
 def main():
@@ -1493,7 +1494,7 @@ def main():
         """)
         
         # Resolve and show example image from docs by walking parent folders
-        img_path = find_in_parents("docs/images/basic_view.png")
+        img_path = TornadoVisualizer.find_in_parents("docs/images/basic_view.png")
         if img_path is not None:
             st.image(
                 str(img_path),

--- a/tornado-visualizer-fixed.py
+++ b/tornado-visualizer-fixed.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Set, Optional, Tuple
 import pandas as pd
 from collections import defaultdict
+from pathlib import Path
 import io
 import base64
 import graphviz
@@ -1364,6 +1365,23 @@ class TornadoVisualizer:
         
         return fig
 
+def find_in_parents(relative_path: str) -> Optional[Path]:
+    """
+    Walk up from this script's directory and return the first path that exists.
+    Example: find_in_parents("docs/images/basic_view.png")
+    """
+    try:
+        start = Path(__file__).resolve().parent
+    except NameError:
+        # Fallback when __file__ is not available (rare in Streamlit)
+        start = Path.cwd().resolve()
+
+    for folder in [start, *start.parents]:
+        candidate = folder / relative_path
+        if candidate.exists():
+            return candidate
+    return None
+
 # Main Streamlit application
 def main():
     # Apply custom CSS for dark theme
@@ -1474,10 +1492,16 @@ def main():
         ### Sample Visualization
         """)
         
-        # Show example image from docs
-        st.image("docs/images/basic_view.png", 
+        # Resolve and show example image from docs by walking parent folders
+        img_path = find_in_parents("docs/images/basic_view.png")
+        if img_path is not None:
+            st.image(
+                str(img_path),
                 caption="Example task graph visualization",
-                use_column_width=True)
+                use_container_width=True
+            )
+        else:
+            st.info("Sample image not found in any parent 'docs/images' folder.")
         return
     
     # Process uploaded file


### PR DESCRIPTION
This patch improves robustness when displaying the sample image in the welcome screen:

Adds `find_in_parents()` helper: walks up parent folders from the script’s location (or CWD if `__file__` is missing) to locate `docs/images/basic_view.png`.

Uses the helper in the welcome screen: instead of hardcoding the relative path, the app now resolves the image even if run from a different working directory or deployment environment.

Fallback handling: if the image is not found in any parent `docs/images` folder, a friendly info message is shown instead of failing silently.

### Why it matters?

Previously, the app assumed it was always run from the project root. However, to run from `TornadoInsight` or extrernal tools, this is not the case.